### PR TITLE
Lodash Vulnerability Fix 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3187,7 +3187,7 @@
                 "lodash._reescape": "^3.0.0",
                 "lodash._reevaluate": "^3.0.0",
                 "lodash._reinterpolate": "^3.0.0",
-                "lodash.template": "^3.0.0",
+                "lodash.template": "4.5.0",
                 "minimist": "^1.1.0",
                 "multipipe": "^0.1.2",
                 "object-assign": "^3.0.0",
@@ -4032,9 +4032,9 @@
             "dev": true
         },
         "lodash.template": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-            "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+            "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
             "dev": true,
             "requires": {
                 "lodash._basecopy": "^3.0.0",
@@ -4045,13 +4045,13 @@
                 "lodash.escape": "^3.0.0",
                 "lodash.keys": "^3.0.0",
                 "lodash.restparam": "^3.0.0",
-                "lodash.templatesettings": "^3.0.0"
+                "lodash.templatesettings": "^4.0.0"
             }
         },
         "lodash.templatesettings": {
-            "version": "3.1.1",
+            "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-            "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+            "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
             "dev": true,
             "requires": {
                 "lodash._reinterpolate": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4050,7 +4050,7 @@
         },
         "lodash.templatesettings": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
             "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
             "dev": true,
             "requires": {


### PR DESCRIPTION
CVE-2019-10744 fixed by updating the lodash.template and lodash.templatesettings versions in order to prevent Prototype Pollution